### PR TITLE
fix

### DIFF
--- a/php/UseCases/Email/SendWeeklyEmails.php
+++ b/php/UseCases/Email/SendWeeklyEmails.php
@@ -161,7 +161,7 @@ class SendWeeklyEmails implements IInteractor
         if (!IsDateValid($date)) {
             return;
         }
-        $datum = GetDutchDateLong(new DateTime());
+        $datum = GetDutchDateLong(new DateTime($date));
         $title = "Zaalwacht " . $datum;
 
         $body = str_replace("{{naam}}", $naam, $body);


### PR DESCRIPTION
Hij maakte een datum gebaseerd de standaard constructor van DatTime, dat de huidige datum terug geeft.
Wanneer je een datum meegeeft aan de constructor, maakt hij een datum gebaseerd op wat je meegaf ([link](http://php.net/manual/en/class.datetime.php#118608)).