### PR TITLE
Tellermail toevoeging hyperlink

### DIFF
--- a/php/Entities/Email/templates/scheidsrechterTemplate.txt
+++ b/php/Entities/Email/templates/scheidsrechterTemplate.txt
@@ -6,6 +6,16 @@ Beste {{naam}},<br>
 Aanstaande {{datum}} moet je een wedstrijd fluiten om {{tijd}}.<br>
 Je zult de wedstrijd {{teams}} gaan fluiten.<br>
 <br>
+Extra informatie over scheidsen vind je door op onderstaande links te klikken.<br>
+SKC website: <a href="https://www.skcvolleybal.nl/index.php/informatie/praktische-info/documenten#"><br>
+Hier zijn de volgende documenten te vinden:<br>
+    - De PowerPoint van de scheidsrechtercursus ‘Scheidsrechters cursus 2021’<br>
+    - De scheidshulp (deze is ook in de zaal aanwezig) ‘Scheidsrechters hulp 2021-2022’<br>
+De Nevobo spelregels:<br>
+<a href="https://www.nevobo.nl/cms/download/7231/Spelregels%202021-2022%20-%20Topdivisie%20en%20lager%20-%20mei%202021.pdf"><br>
+DWF instructievideo: <br>
+<a href="https://www.youtube.com/watch?v=YSYA5cY2r3c&t=1s"><br>
+<br>
 Agenda's Importeren:<br>
 <a target="_blank" href="https://www.google.com/calendar/render?cid=http%3A%2F%2Fwww.skcvolleybal.nl%2Fteam-portal%2Fapi%calendar%3Fuserid%3D{{userId}}">Google Calendar: Fluiten & Zaalwacht</a><br>
 <br>

--- a/php/Entities/Email/templates/scheidsrechterTemplate.txt
+++ b/php/Entities/Email/templates/scheidsrechterTemplate.txt
@@ -1,6 +1,8 @@
 <!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
 <html>
 <body>
+For the English version, scroll down.<br>
+<br>
 Beste {{naam}},<br>
 <br>
 Aanstaande {{datum}} moet je een wedstrijd fluiten om {{tijd}}.<br>
@@ -26,6 +28,33 @@ Met vriendelijke groet,<br>
 <br>
 {{afzender}}<br>
 <br>
-(Dit is een automatisch gegenereerd bericht)
+(Dit is een automatisch gegenereerd bericht)<br>
+<br>
+<br>
+<br>
+<br>
+Dear {{naam}},<br>
+<br>
+Upcoming {{datum}}, you have been assigned as a referee at {{tijd}}.<br>
+You are the referee of the {{teams}} match.<br>
+<br>
+Additional information about being a referee can be found by clicking on the link below.<br>
+SKC website: https://www.skcvolleybal.nl/index.php/informatie/praktische-info/documenten<br>
+The following documents can be found:<br>
+    - The Referee Course PowerPoint ‘Refereecourse 2021’<br>
+    - The Referee help (this is also present in the hall) ‘Referee manual 2021-2022’<br>
+The Nevobo game rules: <br>
+https://www.nevobo.nl/cms/download/7231/Spelregels%202021-2022%20-%20Topdivisie%20en%20lager%20-%20mei%202021.pdf<br>
+DWF instruction video: <br>
+https://www.youtube.com/watch?v=YSYA5cY2r3c&t=1s<br>
+<br>
+Agenda's Import:<br>
+<a target="_blank" href="https://www.google.com/calendar/render?cid=http%3A%2F%2Fwww.skcvolleybal.nl%2Fteam-portal%2Fapi%calendar%3Fuserid%3D{{userId}}">Google Calendar: Fluiten & Zaalwacht</a><br>
+If you import this, all matches are automatically placed in your google calendar and you are aware of all your services at once.<br>
+(It may take a while for your calendar to sync...)<br>
+<br>
+Kind Regards,<br>
+<br>
+{{afzender}}<br>
 </body>
 </html>

--- a/php/Entities/Email/templates/tellerTemplate.txt
+++ b/php/Entities/Email/templates/tellerTemplate.txt
@@ -29,8 +29,8 @@ Met vriendelijke groet,<br>
 <br>
 <br>
 <br>
-Dear [[naam]],
-
+Dear {{naam}},<br>
+<br>
 Upcoming {{datum}}, you have been assigned as a scorekeeper at {{tijd}}.<br>
 You are the scorekeeper of the {{teams}} match.<br>
 <br>

--- a/php/Entities/Email/templates/tellerTemplate.txt
+++ b/php/Entities/Email/templates/tellerTemplate.txt
@@ -2,6 +2,8 @@
 <html>
 <body>
 Beste {{naam}},<br>
+<br> 
+For the English version, scroll down.<br>
 <br>
 Aanstaande {{datum}} moet jouw team een wedstrijd tellen om {{tijd}}.<br>
 Jullie zullen de wedstrijd {{teams}} gaan tellen.<br>
@@ -23,5 +25,30 @@ Tip: Agenda's Importeren:<br>
 Met vriendelijke groet,<br>
 <br>
 {{afzender}}<br>
+<br>
+<br>
+<br>
+<br>
+Dear [[naam]],
+
+Upcoming {{datum}}, you have been assigned as a scorekeeper at {{tijd}}.<br>
+You are the scorekeeper of the {{teams}} match.<br>
+<br>
+Additional information about scorekeeping can be found by clicking on the link below.<br>
+SKC website: <a href="https://www.skcvolleybal.nl/index.php/informatie/praktische-info/documenten"<br>
+The following document can be found:<br>
+    - The DWF manual ‘DWF manual 2021-2022’ <br>
+DWF instruction video:<br>
+<a href="https://www.youtube.com/watch?v=YSYA5cY2r3c&t=1s"><br>
+<br>
+Agenda's Import:<br>
+<a target="_blank" href="https://www.google.com/calendar/render?cid=http%3A%2F%2Fwww.skcvolleybal.nl%2Fteam-portal%2Fapi%calendar%3Fuserid%3D{{userId}}">Google Calendar: Referee & Hallwatch</a><br>
+If you import this, all matches are automatically placed in your google calendar and you are aware of all your services at once.<br>
+(It can take a little while to synchronise with you calendar...)<br>
+<br>
+Kind regards,<br>
+<br>
+{{afzender}}<br>
+<br>
 </body>
 </html>

--- a/php/Entities/Email/templates/tellerTemplate.txt
+++ b/php/Entities/Email/templates/tellerTemplate.txt
@@ -6,8 +6,14 @@ Beste {{naam}},<br>
 Aanstaande {{datum}} moet jouw team een wedstrijd tellen om {{tijd}}.<br>
 Jullie zullen de wedstrijd {{teams}} gaan tellen.<br>
 <br>
-Voor vragen stuur een mail naar scheids@skcvolleybal.nl of stuur een appje naar 0683092391. <br>
+Extra informatie over tellen vind je door op onderstaande links te klikken.<br>
+SKC website: <a href="https://www.skcvolleybal.nl/index.php/informatie/praktische-info/documenten"<br>
+Hier is het volgende document te vinden: <br>
+    - De DWF hulp ‘DWF hulp 2021-2022’ <br>
+DWF instructievideo:<br>
+<a href="https://www.youtube.com/watch?v=YSYA5cY2r3c&t=1s"><br>
 <br>
+Voor vragen stuur een mail naar teamtakenco@skcvolleybal.nl<br>
 Vergeet verder vooral niet de wedstrijd live bij te houden op het DWF. Dit is tenslotte verplicht. Mocht je hier verdere vragen over hebben, dan kan je altijd bij de aanwezige bestuursleden terecht.<br>
 <br>
 Tip: Agenda's Importeren:<br>
@@ -17,7 +23,5 @@ Tip: Agenda's Importeren:<br>
 Met vriendelijke groet,<br>
 <br>
 {{afzender}}<br>
-<br>
-(Dit is een automatisch gegenereerd bericht)
 </body>
 </html>


### PR DESCRIPTION
De content van de scheids en tellermail templates zijn aangepast. Ook is er aan beide een engelste vertaling aan toegevoegd met dezelfde placeholders.
Verder zijn er extra links in beide mails toegevoegd die verwijzen naar filmpjes op Youtube en documenten op de SKC-website.